### PR TITLE
A couple of issues solved.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ stacktrace.log
 .idea
 *.zip
 *.iml
+*.sha1
+*.*~

--- a/MybatisGrailsPlugin.groovy
+++ b/MybatisGrailsPlugin.groovy
@@ -9,7 +9,7 @@ import org.grails.plugins.mybatis.TypeHandlerArtefactHandler
 import org.grails.plugins.mybatis.locking.OptimisticLockingInterceptor
 
 class MybatisGrailsPlugin {
-  def version = "0.0.2.1"
+  def version = "0.0.2.2"
   def grailsVersion = "2.0 > *"
   def dependsOn = [:]
   def pluginExcludes = [

--- a/MybatisGrailsPlugin.groovy
+++ b/MybatisGrailsPlugin.groovy
@@ -9,7 +9,7 @@ import org.grails.plugins.mybatis.TypeHandlerArtefactHandler
 import org.grails.plugins.mybatis.locking.OptimisticLockingInterceptor
 
 class MybatisGrailsPlugin {
-  def version = "0.0.2"
+  def version = "0.0.2.1"
   def grailsVersion = "2.0 > *"
   def dependsOn = [:]
   def pluginExcludes = [

--- a/README.md
+++ b/README.md
@@ -16,4 +16,5 @@ Modifications:
  - Added support for custom Enum persistance (based on enum property value - to make DBA-s happy)
 
 Documenation: http://fzilic.github.com/Grails-MyBatis/
- - documentation review needed
+- documentation review needed
+- Also check the notes of arief-hidayat http://www.ariefhidayat.com/grails-mybatis/

--- a/application.properties
+++ b/application.properties
@@ -1,7 +1,5 @@
-#Grails Metadata file
-#Fri Jul 06 14:40:01 CEST 2012
-app.grails.version=2.0.3
+#Thu Jun 04 20:23:53 CDT 2015
+app.grails.version=2.3.11
 app.name=mybatis
-plugins.hibernate=2.0.3
-plugins.release=2.0.3
-plugins.tomcat=2.0.3
+app.servlet.version=2.5
+plugins.release=3.1.1

--- a/install_plugin.sh
+++ b/install_plugin.sh
@@ -1,0 +1,2 @@
+grails refresh-dependencies
+grails maven-install

--- a/scripts/_Events.groovy
+++ b/scripts/_Events.groovy
@@ -1,0 +1,6 @@
+eventCreateWarStart = { warName, stagingDir ->
+    //println "Inside the Plugin Script"
+    ant.copy(todir: "${stagingDir}/WEB-INF/classes") {
+        fileset(dir:"grails-app/gateways",includes:"**/*.xml")
+    }
+}

--- a/scripts/_Install.groovy
+++ b/scripts/_Install.groovy
@@ -10,3 +10,5 @@
 //
 ant.mkdir(dir:"${basedir}/grails-app/gateways")
 ant.mkdir(dir:"${basedir}/grails-app/typeHandlers")
+
+//ant.copy(file:"${pluginBasedir}/scripts/_Events.groovy", todir:"${basedir}/scripts")

--- a/src/groovy/org/grails/plugins/mybatis/MappingSupport.groovy
+++ b/src/groovy/org/grails/plugins/mybatis/MappingSupport.groovy
@@ -129,7 +129,7 @@ class MappingSupport {
       return null
     }
 
-    XmlSlurper xmlSlurper = new XmlSlurper(validating, true)
+    XmlSlurper xmlSlurper = new XmlSlurper(validating, true, true)
     xmlSlurper.entityResolver = resolver as EntityResolver
 
     return xmlSlurper.parseText(mappingFileText)


### PR DESCRIPTION
The original 0.0.2 version has had a couple of issues that are resolved in this request
.
The first one is mentioned in issue #8 so I have added a "scripts/_Events.groovy" file that includes the XML mapper files in the user's project WAR whenever it is created.

The second one is issue #7 and is already known (http://stackoverflow.com/questions/29176515/grails-2-4-4-with-mybatis-plugin-doctype-is-disallowed-cant-load-any-mapper) as it throws the error: DOCTYPE disallowed when the feature "http://apache.org/xml/features/disallow-doctype-decl" set to true. Making it impossible to read the XML mappers.
So I slightly modified src/groovy/org/grails/plugins/mybatis/MappingSupport.groovy (line 32) to fix this.
